### PR TITLE
Work-around for pygalmesh on Mac/Windows

### DIFF
--- a/.github/workflows/test_on_linux.yml
+++ b/.github/workflows/test_on_linux.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Test with pytest
         shell: bash -l {0}
-        run: python -m pytest
+        run: python -m pytest --disable-warnings

--- a/.github/workflows/test_on_macos.yaml
+++ b/.github/workflows/test_on_macos.yaml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Test with pytest
         shell: bash
-        run: python -m pytest
+        run: python -m pytest --disable-warnings

--- a/.github/workflows/test_on_windows.yaml
+++ b/.github/workflows/test_on_windows.yaml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Test with pytest
         shell: pwsh
-        run: python -m pytest
+        run: python -m pytest --disable-warnings

--- a/.github/workflows/test_on_windows.yaml
+++ b/.github/workflows/test_on_windows.yaml
@@ -37,10 +37,6 @@ jobs:
       #   run: |
       #     vcpkg install eigen3 cgal
 
-      - name: Install libraries with vcpkg
-        run: |
-          vcpkg install eigen3 cgal
-
       - name: Python info
         shell: pwsh
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: |
   \.vol
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -20,7 +20,7 @@ repos:
       - id: debug-statements
       - id: double-quote-string-fixer
   - repo: https://github.com/kynan/nbstripout
-    rev: master
+    rev: 0.4.0
     hooks:
       - id: nbstripout
         files: ".ipynb"
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: docformatter
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.9.1'
+    rev: '3.9.2'
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # nanomesh
 
-Creates 3d meshes from electron microscopy experimental data
+Creates 3d meshes from microscopy experimental data.
 
 The project setup is documented in [a separate document](project_setup.rst). Feel free to remove this document (and/or
 the link to this document) if you don\'t need it.
@@ -39,7 +39,7 @@ Note: To enable the IPython widgets:
 jupyter nbextension enable --py widgetsnbextension
 ```
 
-Note: If you are using Jupyter lab:
+Note, [if you are using Jupyter lab](https://github.com/InsightSoftwareConsortium/itkwidgets#installation):
 
 ```
 jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets

--- a/nanomesh/structures.py
+++ b/nanomesh/structures.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+
 import pygalmesh
 
 from nanomesh.generator import Generator
@@ -65,6 +66,7 @@ class Pore3D(pygalmesh.DomainBase):
         return out
 
 
+@requires(condition=pygalmesh, message='pygalmesh is not installed')
 class FullCube(pygalmesh.DomainBase):
     def __init__(self):
         super().__init__()

--- a/nanomesh/structures.py
+++ b/nanomesh/structures.py
@@ -1,7 +1,6 @@
 import math
 
 import numpy as np
-
 import pygalmesh
 
 from nanomesh.generator import Generator

--- a/nanomesh/structures.py
+++ b/nanomesh/structures.py
@@ -66,7 +66,6 @@ class Pore3D(pygalmesh.DomainBase):
         return out
 
 
-@requires(condition=pygalmesh, message='pygalmesh is not installed')
 class FullCube(pygalmesh.DomainBase):
     def __init__(self):
         super().__init__()

--- a/nanomesh/utils.py
+++ b/nanomesh/utils.py
@@ -1,10 +1,10 @@
+import warnings
+
 import itkwidgets as itkw
 import matplotlib.pyplot as plt
 import numpy as np
-
 import SimpleITK as sitk
 from ipywidgets import interact
-import warnings
 
 try:
     import pygalmesh
@@ -12,23 +12,22 @@ except ImportError:
     pygalmesh = None
 
 
-
 class requires:
     """Decorate functions to mark them as unavailable based if `condition` does
-    not evaluate to `True`.
-    """
-
+    not evaluate to `True`."""
     def __init__(self, *, condition, message='requires optional dependencies'):
         self.condition = condition
         self.message = message
 
     def __call__(self, func):
         if not self.condition:
+
             def dummy(*args, **kwargs):
-                warnings.warn(f"`{func.__qualname__}` {self.message}.")
+                warnings.warn(f'`{func.__qualname__}` {self.message}.')
+
             return dummy
         else:
-           return func
+            return func
 
 
 def show_slice(img,

--- a/nanomesh/utils.py
+++ b/nanomesh/utils.py
@@ -24,7 +24,7 @@ class requires:
 
     def __call__(self, func):
         if not self.condition:
-            def dummy(self, *args, **kwargs):
+            def dummy(*args, **kwargs):
                 warnings.warn(f"`{func.__qualname__}` {self.message}.")
             return dummy
         else:

--- a/nanomesh/utils.py
+++ b/nanomesh/utils.py
@@ -1,9 +1,34 @@
 import itkwidgets as itkw
 import matplotlib.pyplot as plt
 import numpy as np
-import pygalmesh
+
 import SimpleITK as sitk
 from ipywidgets import interact
+import warnings
+
+try:
+    import pygalmesh
+except ImportError:
+    pygalmesh = None
+
+
+
+class requires:
+    """Decorate functions to mark them as unavailable based if `condition` does
+    not evaluate to `True`.
+    """
+
+    def __init__(self, *, condition, message='requires optional dependencies'):
+        self.condition = condition
+        self.message = message
+
+    def __call__(self, func):
+        if not self.condition:
+            def dummy(self, *args, **kwargs):
+                warnings.warn(f"`{func.__qualname__}` {self.message}.")
+            return dummy
+        else:
+           return func
 
 
 def show_slice(img,
@@ -125,6 +150,7 @@ def show_volume(data):
     return itkw.view(data)
 
 
+@requires(condition=pygalmesh, message='requires pygalmesh')
 def generate_mesh_from_binary_image(img, h=(1.0, 1.0, 1.0), **kwargs):
     """Generate mesh from binary image using pygalmesh.
 

--- a/nanomesh/volume.py
+++ b/nanomesh/volume.py
@@ -10,7 +10,7 @@ from .utils import show_slice, requires
 try:
     import pygalmesh
 except ImportError:
-    pygalmesh is None
+    pygalmesh = None
 
 logger = logging.getLogger(__name__)
 

--- a/nanomesh/volume.py
+++ b/nanomesh/volume.py
@@ -74,7 +74,7 @@ class Volume:
         Volume
             New instance of `Volume`.
         """
-        new_image = function(self.array_view, **kwargs)
+        new_image = function(self.image, **kwargs)
         return Volume(new_image)
 
     def show_slice(self, along: str = 'x', overlay=None, **kwargs):

--- a/nanomesh/volume.py
+++ b/nanomesh/volume.py
@@ -5,7 +5,12 @@ import numpy as np
 import SimpleITK as sitk
 
 from .plane import Plane
-from .utils import show_slice
+from .utils import show_slice, requires
+
+try:
+    import pygalmesh
+except ImportError:
+    pygalmesh is None
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +99,7 @@ class Volume:
         else:
             raise ValueError(f'No such renderer: {renderer!r}')
 
+    @requires(condition=pygalmesh, message='pygalmesh is not installed')
     def generate_mesh(self, h=(1.0, 1.0, 1.0), **kwargs) -> 'meshio.Mesh':
         """Generate mesh from binary image.
 
@@ -109,7 +115,6 @@ class Volume:
         meshio.Mesh
             Mesh representation of volume.
         """
-        import pygalmesh
         mesh = pygalmesh.generate_from_array(self.array_view, h, **kwargs)
         return mesh
 

--- a/nanomesh/volume.py
+++ b/nanomesh/volume.py
@@ -99,7 +99,7 @@ class Volume:
         else:
             raise ValueError(f'No such renderer: {renderer!r}')
 
-    @requires(condition=pygalmesh, message='pygalmesh is not installed')
+    @requires(condition=pygalmesh, message='requires pygalmesh')
     def generate_mesh(self, h=(1.0, 1.0, 1.0), **kwargs) -> 'meshio.Mesh':
         """Generate mesh from binary image.
 

--- a/nanomesh/volume.py
+++ b/nanomesh/volume.py
@@ -5,7 +5,7 @@ import numpy as np
 import SimpleITK as sitk
 
 from .plane import Plane
-from .utils import show_slice, requires
+from .utils import requires, show_slice
 
 try:
     import pygalmesh

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,13 +1,10 @@
 import numpy as np
 
 
-def assert_mesh_almost_equal(this, other):
+def assert_mesh_almost_equal(this, other, tol=0.0):
     """Compare two meshes."""
-    # There is a minor discrepancy between the generated points between
-    # Linux/Mac and Windows. Allow for some deviation.
-    tolerance = 0.0025
     dist = np.linalg.norm(this.points - other.points, axis=1)
-    assert dist.mean() < tolerance
+    assert dist.mean() < tol
 
     this_cells = this.cells_dict
     other_cells = other.cells_dict

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -3,7 +3,11 @@ import numpy as np
 
 def assert_mesh_almost_equal(this, other):
     """Compare two meshes."""
-    assert np.allclose(this.points, other.points)
+    # There is a minor discrepancy between the generated points between
+    # Linux/Mac and Windows. Allow for some deviation.
+    tolerance = 0.0025
+    dist = np.linalg.norm(this.points - other.points, axis=1)
+    assert dist.mean() < tolerance
 
     this_cells = this.cells_dict
     other_cells = other.cells_dict

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -3,8 +3,11 @@ import numpy as np
 
 def assert_mesh_almost_equal(this, other, tol=0.0):
     """Compare two meshes."""
-    dist = np.linalg.norm(this.points - other.points, axis=1)
-    assert dist.mean() < tol
+    if tol:
+        dist = np.linalg.norm(this.points - other.points, axis=1)
+        assert dist.mean() < tol
+    else:
+        assert np.allclose(this.points, other.points)
 
     this_cells = this.cells_dict
     other_cells = other.cells_dict

--- a/tests/test_full_periodic.py
+++ b/tests/test_full_periodic.py
@@ -2,10 +2,11 @@ import pickle
 from pathlib import Path
 
 import helpers
-import pygalmesh
+import pytest
+
+pygalmesh = pytest.importorskip("pygalmesh")
 
 from nanomesh.structures import XDIM, YDIM, ZDIM, Pore3D
-
 
 def test_full_periodic_1domain():
     """Test whether Pore3D gives the expected result with pygalmesh."""

--- a/tests/test_full_periodic.py
+++ b/tests/test_full_periodic.py
@@ -4,9 +4,10 @@ from pathlib import Path
 import helpers
 import pytest
 
-pygalmesh = pytest.importorskip("pygalmesh")
+pygalmesh = pytest.importorskip('pygalmesh')
 
 from nanomesh.structures import XDIM, YDIM, ZDIM, Pore3D
+
 
 def test_full_periodic_1domain():
     """Test whether Pore3D gives the expected result with pygalmesh."""

--- a/tests/test_mesh_2d.py
+++ b/tests/test_mesh_2d.py
@@ -1,17 +1,17 @@
 import pickle
+import sys
 from pathlib import Path
 
 import helpers
 import numpy as np
 import pytest
-import sys
 from matplotlib.testing.decorators import image_comparison
 
 from nanomesh.mesh2d import (add_edge_points, add_points_grid,
                              add_points_kmeans, generate_2d_mesh,
                              subdivide_contour)
 
-# Reference points were generated on Linux. There is a minor difference 
+# Reference points were generated on Linux. There is a minor difference
 # between the generated on Linux/Mac and Windows. Allow for some deviation.
 windows = (sys.platform == 'win32')
 

--- a/tests/test_mesh_2d.py
+++ b/tests/test_mesh_2d.py
@@ -4,11 +4,16 @@ from pathlib import Path
 import helpers
 import numpy as np
 import pytest
+import sys
 from matplotlib.testing.decorators import image_comparison
 
 from nanomesh.mesh2d import (add_edge_points, add_points_grid,
                              add_points_kmeans, generate_2d_mesh,
                              subdivide_contour)
+
+# Reference points were generated on Linux. There is a minor difference 
+# between the generated on Linux/Mac and Windows. Allow for some deviation.
+windows = (sys.platform == 'win32')
 
 
 @pytest.fixture
@@ -24,6 +29,7 @@ def segmented():
     remove_text=True,
     extensions=['png'],
     savefig_kwarg={'bbox_inches': 'tight'},
+    tol=2.0 if windows else 0,
 )
 def test_generate_2d_mesh(segmented):
     """Test 2D mesh generation and plot."""
@@ -45,7 +51,8 @@ def test_generate_2d_mesh(segmented):
 
         raise RuntimeError(f'Wrote expected mesh to {expected_fn.absolute()}')
 
-    helpers.assert_mesh_almost_equal(mesh, expected_mesh)
+    tol = 0.0025 if windows else 0
+    helpers.assert_mesh_almost_equal(mesh, expected_mesh, tol=tol)
 
 
 def test_add_edge_points():


### PR DESCRIPTION
Avoid requiring pygalmesh if it can be avoided, so that (parts of) the package can be installed/tested on Mac/Windows.

Closes #35 
Closes #36 