### PR TITLE
Fixes the command to run tetgen

### DIFF
--- a/nanomesh/tetgen.py
+++ b/nanomesh/tetgen.py
@@ -92,4 +92,4 @@ def tetrahedralize(fname: os.PathLike, opts: str = '-pAq1.2'):
     # -a: Applies a maximum tetrahedron volume constraint.
 
     import subprocess as sp
-    sp.run(f'tetgen {opts} {fname}')
+    sp.run(['tetgen', opts, fname])


### PR DESCRIPTION
The previous version only worked on Windows, as there it would automatically split the string on spaces. On POSIX platforms it would not split the string and try to find a program matching the whole string.

This is as yet untested on Windows (no access) and Mac (no tetgen installed yet).

Fixes #141 