### PR TITLE
Move `simple_triangulate` to own submodule

### DIFF
--- a/nanomesh/__init__.py
+++ b/nanomesh/__init__.py
@@ -2,10 +2,11 @@ import logging
 import sys
 
 from .mesh import LineMesh, TetraMesh, TriangleMesh
-from .mesh2d import Mesher2D, compare_mesh_with_image, simple_triangulate
+from .mesh2d import Mesher2D, compare_mesh_with_image
 from .mesh3d import Mesher3D
 from .mesh_container import MeshContainer
 from .plane import Plane
+from .triangulate import simple_triangulate
 from .volume import Volume
 
 logging.basicConfig(format='%(message)s',

--- a/nanomesh/mesh.py
+++ b/nanomesh/mesh.py
@@ -330,7 +330,7 @@ class LineMesh(BaseMesh):
 
     def triangulate(self, opts: str = 'pq30Aa100') -> MeshContainer:
         """Triangulate mesh using `triangle`."""
-        from .mesh2d.helpers import simple_triangulate
+        from .triangulate import simple_triangulate
         points = self.points
         segments = self.cells
         regions = [(*m.point, m.label, 0) for m in self.region_markers]

--- a/nanomesh/mesh2d/__init__.py
+++ b/nanomesh/mesh2d/__init__.py
@@ -1,4 +1,4 @@
-from .helpers import compare_mesh_with_image, pad, simple_triangulate
+from .helpers import compare_mesh_with_image, pad
 from .mesher import Mesher2D, generate_2d_mesh
 
 __all__ = [
@@ -6,5 +6,4 @@ __all__ = [
     'generate_2d_mesh',
     'Mesher2D',
     'pad',
-    'simple_triangulate',
 ]

--- a/nanomesh/mesh2d/helpers.py
+++ b/nanomesh/mesh2d/helpers.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
-import triangle as tr
 from scipy.spatial.distance import cdist
 
 from ..region_markers import RegionMarker
 
 if TYPE_CHECKING:
     from nanomesh.mesh import LineMesh, TriangleMesh
-    from nanomesh.mesh_container import MeshContainer
 
 
 def compare_mesh_with_image(image: np.ndarray, mesh: TriangleMesh):
@@ -38,52 +36,6 @@ def compare_mesh_with_image(image: np.ndarray, mesh: TriangleMesh):
     ax.set_yticks([])
 
     return ax
-
-
-def simple_triangulate(points: np.ndarray,
-                       *,
-                       segments: np.ndarray = None,
-                       regions: List[Tuple[float, ...]] = None,
-                       opts: str = '') -> MeshContainer:
-    """Simple triangulation using `triangle`.
-
-    Parameters
-    ----------
-    points : i,2 np.ndarray
-        Vertex coordinates.
-    segments : j,2 np.ndarray, optional
-        Index array describing segments.
-        Segments are edges whose presence in the triangulation
-        is enforced (although each segment may be subdivided into smaller
-        edges). Each segment is specified by listing the indices of its
-        two endpoints. A closed set of segments describes a contour.
-    regions : k,2 np.ndarray, optional
-        Coordinates describing regions. A region is a coordinate inside
-        (e.g. at the center) of a region/contour (i.e. enclosed by segments).
-    opts : str, optional
-        Additional options passed to `triangle.triangulate` documented here:
-        https://rufat.be/triangle/API.html#triangle.triangulate
-
-    Returns
-    -------
-    mesh : MeshContainer
-        Triangle mesh
-    """
-    from nanomesh.mesh_container import MeshContainer
-
-    triangle_dict_in: Dict['str', Any] = {'vertices': points}
-
-    if segments is not None:
-        triangle_dict_in['segments'] = segments
-
-    if regions is not None:
-        triangle_dict_in['regions'] = regions
-
-    triangle_dict_out = tr.triangulate(triangle_dict_in, opts=opts)
-
-    mesh = MeshContainer.from_triangle_dict(triangle_dict_out)
-
-    return mesh
 
 
 def pad(

--- a/nanomesh/mesh3d/mesher.py
+++ b/nanomesh/mesh3d/mesher.py
@@ -9,10 +9,10 @@ import numpy as np
 from skimage import measure, morphology
 
 from nanomesh._mesh_shared import BaseMesher
-from nanomesh.mesh2d import simple_triangulate
 from nanomesh.volume import Volume
 
 from ..region_markers import RegionMarker, RegionMarkerLike
+from ..triangulate import simple_triangulate
 from .bounding_box import BoundingBox
 from .helpers import pad
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from nanomesh import simple_triangulate
 from nanomesh.mesh import TriangleMesh
-from nanomesh.mesh2d import simple_triangulate
 from nanomesh.utils import SliceViewer
 
 


### PR DESCRIPTION
This PR moves `simple_triangulate` to its own submodule to make it easier to access.