### PR TITLE
Doc decorator

### DIFF
--- a/nanomesh/_doc.py
+++ b/nanomesh/_doc.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import functools
+import inspect
+import types
+from textwrap import dedent
+from typing import Any, Callable, TypeVar
+
+# BaseclassMeta is derived from: https://stackoverflow.com/a/40613306
+
+
+def copy_func(f):
+    """Make a copy of function `f`."""
+    g = types.FunctionType(f.__code__,
+                           f.__globals__,
+                           name=f.__name__,
+                           argdefs=f.__defaults__,
+                           closure=f.__closure__)
+    g = functools.update_wrapper(g, f)
+    g.__kwdefaults__ = f.__kwdefaults__
+    return g
+
+
+class BaseclassMeta(type):
+
+    def __new__(mcls, classname, bases, cls_dict):
+        cls = super().__new__(mcls, classname, bases, cls_dict)
+
+        for name, method in inspect.getmembers(cls):
+            if name.startswith('_'):
+                continue
+
+            bound_classname = method.__qualname__.split('.')[0]
+
+            if bound_classname == classname:
+                continue
+
+            for parent in cls.mro()[1:]:
+                if hasattr(parent, name):
+                    new_method = copy_func(method)
+                    new_method.__doc__ = method.__doc__.format(cls=classname)
+                    setattr(cls, name, new_method)
+
+                    break
+
+        return cls
+
+
+FuncType = Callable[..., Any]
+F = TypeVar('F', bound=FuncType)
+
+# `doc` is derived from pandas.util._decorators (1.4.1)
+# https://github.com/pandas-dev/pandas/blob/main/LICENSE
+
+
+def doc(*docstrings: str | Callable, **params) -> Callable[[F], F]:
+    """
+    A decorator take docstring templates, concatenate them and perform string
+    substitution on it.
+    This decorator will add a variable "_docstring_components" to the wrapped
+    callable to keep track the original docstring template for potential usage.
+    If it should be consider as a template, it will be saved as a string.
+    Otherwise, it will be saved as callable, and later user __doc__ and dedent
+    to get docstring.
+    Parameters
+    ----------
+    *docstrings : str or callable
+        The string / docstring / docstring template to be appended in order
+        after default docstring under callable.
+    **params
+        The string which would be used to format docstring template.
+    """
+
+    def decorator(decorated: F) -> F:
+        # collecting docstring and docstring templates
+        docstring_components: list[str | Callable] = []
+        if decorated.__doc__:
+            docstring_components.append(dedent(decorated.__doc__))
+
+        for docstring in docstrings:
+            if hasattr(docstring, '_docstring_components'):
+                # error: Item "str" of "Union[str, Callable[..., Any]]" has no
+                # attribute "_docstring_components"
+                # error: Item "function" of "Union[str, Callable[..., Any]]"
+                # has no attribute "_docstring_components"
+                docstring_components.extend(
+                    docstring._docstring_components  # type: ignore[union-attr]
+                )
+            elif isinstance(docstring, str) or docstring.__doc__:
+                docstring_components.append(docstring)
+
+        # formatting templates and concatenating docstring
+        decorated.__doc__ = ''.join([
+            component.format(**params)
+            if isinstance(component, str) else dedent(component.__doc__ or '')
+            for component in docstring_components
+        ])
+
+        # error: "F" has no attribute "_docstring_components"
+        decorated._docstring_components = (  # type: ignore[attr-defined]
+            docstring_components)
+        return decorated
+
+    return decorator

--- a/nanomesh/image/_base.py
+++ b/nanomesh/image/_base.py
@@ -4,6 +4,8 @@ from typing import Callable, Union
 
 import numpy as np
 
+from .._doc import BaseclassMeta, doc
+
 
 def _normalize_values(image: np.ndarray):
     """Rescale values to 0.0 to 1.0.
@@ -22,17 +24,18 @@ def _normalize_values(image: np.ndarray):
     return out
 
 
-class BaseImage:
-    """Data class for image data.
+@doc(prefix='Base class for image data', shape='')
+class BaseImage(object, metaclass=BaseclassMeta):
+    """{prefix}.
 
     Parameters
     ----------
-    image : numpy.array
+    image : {shape}numpy.array
         N-dimensional numpy array containing image data.
 
     Attributes
     ----------
-    image : numpy.ndarray
+    image : {shape}numpy.ndarray
         The raw image data
     """
 
@@ -77,7 +80,7 @@ class BaseImage:
 
         Returns
         -------
-        BaseImage
+        {cls}
             Image with boolean data.
         """
         this = self.image
@@ -87,7 +90,7 @@ class BaseImage:
 
     def to_sitk_image(self):
         """Return instance of :class:`SimpleITK.Image` from
-        :meth:`BaseImage.image`."""
+        :meth:`{cls}.image`."""
         import SimpleITK as sitk
         return sitk.GetImageFromArray(self.image)
 
@@ -123,21 +126,21 @@ class BaseImage:
         return cls(image)
 
     def apply(self, function: Callable, **kwargs):
-        """Apply function to :attr:`BaseImage.image` array. Return an instance
-        of :class:`BaseImage` if the result is of the same dimensions,
-        otherwise return the result of the operation.
+        """Apply function to :attr:`{cls}.image` array. Return an instance of
+        :class:`{cls}` if the result is of the same dimensions, otherwise
+        return the result of the operation.
 
         Parameters
         ----------
         function : callable
-            Function to apply to :attr:`BaseImage.image`.
+            Function to apply to :attr:`{cls}.image`.
         **kwargs
             Keyword arguments to pass to `function`.
 
         Returns
         -------
-        BaseImage
-            New instance of :class:`BaseImage`.
+        {cls}
+            New instance of :class:`{cls}`.
         """
         ret = function(self.image, **kwargs)
         if isinstance(ret, np.ndarray) and (ret.ndim == self.image.ndim):
@@ -157,8 +160,8 @@ class BaseImage:
 
         Returns
         -------
-        BaseImage
-            New instance of :class:`BaseImage`.
+        {cls}
+            New instance of :class:`{cls}`.
         """
         from skimage import filters
         return self.apply(filters.gaussian, sigma=sigma, **kwargs)
@@ -177,8 +180,8 @@ class BaseImage:
 
         Returns
         -------
-        BaseImage
-            New instance of :class:`BaseImage`.
+        {cls}
+            New instance of :class:`{cls}`.
         """
         return self.apply(np.digitize, bins=bins, **kwargs)
 
@@ -187,7 +190,7 @@ class BaseImage:
 
         Returns
         -------
-        out : BaseImage
+        out : {cls}
             Normalized image
         """
         return self.apply(_normalize_values)
@@ -197,7 +200,7 @@ class BaseImage:
 
         Returns
         -------
-        out : BaseImage
+        out : {cls}
             Inverted image
         """
         return self.apply(lambda arr: arr.max() - arr)
@@ -209,13 +212,13 @@ class BaseImage:
         ----------
         threshold : float, optional
             Threshold used for segmentation. If given as a string,
-            apply corresponding theshold via :meth:`BaseImage.threshold`.
+            apply corresponding theshold via :meth:`{cls}.threshold`.
             Defaults to `median`.
 
         Returns
         -------
-        BaseImage
-            New instance of :class:`BaseImage`.
+        {cls}
+            New instance of :class:`{cls}`.
         """
         if not threshold:
             threshold = np.median(self.image)
@@ -266,7 +269,7 @@ class BaseImage:
 
         Returns
         -------
-        BaseImage
+        {cls}
             Real component of fourier transform with the zero-frequency
             component shifted to the center of the spectrum.
         """

--- a/nanomesh/image/_plane.py
+++ b/nanomesh/image/_plane.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Union
 import matplotlib.pyplot as plt
 import numpy as np
 
+from .._doc import doc
 from ._base import BaseImage
 from ._utils import show_image
 
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
     from .mesh import TriangleMesh
 
 
+@doc(BaseImage,
+     prefix='Data class for working with 2D image data',
+     shape='(i,j) ')
 class Plane(BaseImage):
 
     @classmethod

--- a/nanomesh/image/_volume.py
+++ b/nanomesh/image/_volume.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Tuple, Union
 
 import numpy as np
 
+from .._doc import doc
 from ..io import load_vol
 from ._base import BaseImage
 from ._plane import Plane
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@doc(BaseImage,
+     prefix='Data class for working with 3D (volumetric) image data',
+     shape='(i,j,k) ')
 class Volume(BaseImage):
 
     @classmethod
@@ -58,7 +62,7 @@ class Volume(BaseImage):
         return cls(array)
 
     def apply(self, function: Callable, **kwargs) -> 'Volume':
-        """Apply function to `.image` array. Return an instance of
+        """Apply function to :attr:`Volume.image` array. Return an instance of
         :class:`Volume` if the result is a 3D image, otherwise return the
         result of the operation.
 

--- a/nanomesh/image2mesh/_base.py
+++ b/nanomesh/image2mesh/_base.py
@@ -6,14 +6,16 @@ from typing import Union
 
 import numpy as np
 
+from .._doc import doc
 from ..image import Plane, Volume
 from ..mesh._base import BaseMesh
 
 logger = logging.getLogger(__name__)
 
 
+@doc(prefix='mesh from image data')
 class BaseMesher(ABC):
-    """Utility class to mesh image data and generate a mesh.
+    """Utility class to generate a {prefix}.
 
     Parameters
     ----------

--- a/nanomesh/image2mesh/mesher2d/_mesher.py
+++ b/nanomesh/image2mesh/mesher2d/_mesher.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.spatial.distance import cdist
 from skimage import measure
 
+from nanomesh._doc import doc
 from nanomesh.region_markers import RegionMarker
 
 from .._base import BaseMesher
@@ -159,6 +160,7 @@ def _generate_segments(polygons: List[Polygon]) -> np.ndarray:
     return np.vstack(segments)
 
 
+@doc(BaseMesher, prefix='triangular mesh from 2D image data')
 class Mesher2D(BaseMesher):
 
     def __init__(self, image: np.ndarray | Plane):
@@ -318,7 +320,7 @@ def plane2mesh(image: np.ndarray | Plane,
                max_contour_dist: int = 5,
                opts: str = 'q30a100',
                plot: bool = False) -> 'MeshContainer':
-    """Generate mesh from binary (segmented) image.
+    """Generate a triangular mesh from a 2D segmented image.
 
     Parameters
     ----------

--- a/nanomesh/image2mesh/mesher3d/_mesher.py
+++ b/nanomesh/image2mesh/mesher3d/_mesher.py
@@ -8,6 +8,7 @@ import numpy as np
 from skimage import measure, morphology
 
 from nanomesh import triangulate
+from nanomesh._doc import doc
 from nanomesh.image import Volume
 from nanomesh.region_markers import RegionMarker, RegionMarkerLike
 
@@ -229,6 +230,7 @@ def generate_envelope(mesh: TriangleMesh,
     return mesh
 
 
+@doc(BaseMesher, prefix='tetrahedral mesh from 3D (volumetric) image data')
 class Mesher3D(BaseMesher):
 
     def __init__(self, image: np.ndarray):
@@ -362,7 +364,7 @@ def volume2mesh(
     level: float = None,
     **kwargs,
 ) -> 'MeshContainer':
-    """Generate mesh from binary (segmented) image.
+    """Generate a tetrahedral mesh from a 3D segmented image.
 
     Parameters
     ----------

--- a/nanomesh/mesh/_base.py
+++ b/nanomesh/mesh/_base.py
@@ -7,13 +7,15 @@ import meshio
 import numpy as np
 import pyvista as pv
 
+from .._doc import doc
 from ..region_markers import RegionMarker, RegionMarkerLike
 
 registry: Dict[str, Any] = {}
 
 
+@doc(prefix='Base class for meshes')
 class BaseMesh:
-    """Base class for meshes.
+    """{prefix}.
 
     Parameters
     ----------

--- a/nanomesh/mesh/_line.py
+++ b/nanomesh/mesh/_line.py
@@ -5,12 +5,14 @@ from typing import TYPE_CHECKING, Optional
 import matplotlib.pyplot as plt
 import numpy as np
 
+from .._doc import doc
 from ._base import BaseMesh
 
 if TYPE_CHECKING:
     from ..mesh_container import MeshContainer
 
 
+@doc(BaseMesh, prefix='Data class for line meshes')
 class LineMesh(BaseMesh):
     cell_type = 'line'
 

--- a/nanomesh/mesh/_tetra.py
+++ b/nanomesh/mesh/_tetra.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import numpy as np
 import pyvista as pv
 
+from .._doc import doc
 from ._base import BaseMesh
 
 
+@doc(BaseMesh, prefix='Data class for tetrahedral meshes')
 class TetraMesh(BaseMesh):
     cell_type = 'tetra'
 

--- a/nanomesh/mesh/_triangle.py
+++ b/nanomesh/mesh/_triangle.py
@@ -7,6 +7,7 @@ import numpy as np
 import pyvista as pv
 import scipy
 
+from .._doc import doc
 from ._base import BaseMesh
 from ._mixin import PruneZ0Mixin
 
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
     from nanomesh import MeshContainer
 
 
+@doc(BaseMesh, prefix='Data class for triangle meshes')
 class TriangleMesh(BaseMesh, PruneZ0Mixin):
     cell_type = 'triangle'
 

--- a/nanomesh/metrics.py
+++ b/nanomesh/metrics.py
@@ -1,3 +1,5 @@
+"""Module to compute cell quality metrics."""
+
 from dataclasses import dataclass
 from typing import Callable, Optional, Tuple
 

--- a/nanomesh/region_markers.py
+++ b/nanomesh/region_markers.py
@@ -12,7 +12,7 @@ import numpy.typing as npt
 
 @dataclass
 class RegionMarker:
-    """Dataclass to store region info.
+    """Data class to store region info.
 
     A region is typically an area or volume bounded
     by segments or cells.


### PR DESCRIPTION
This PR adds a decorator and metaclass to re-use docstrings. This is useful for methods on data types, which are essentially shortcuts for functions, but re-use many of the same arguments. It also ensures that methods have correct return types (i.e. `Plane` instead of `BaseImage`)

Closes #227
Closes #233 