### PR TITLE
Rename base types

### DIFF
--- a/nanomesh/image/__init__.py
+++ b/nanomesh/image/__init__.py
@@ -1,3 +1,4 @@
+from ._base import GenericImage
 from ._plane import Plane
 from ._roi2d import extract_rectangle, minimum_bounding_rectangle
 from ._utils import SliceViewer, show_image
@@ -6,6 +7,7 @@ from ._volume import Volume
 __all__ = [
     'Volume',
     'Plane',
+    'GenericImage',
     'show_image',
     'SliceViewer',
     'minimum_bounding_rectangle',

--- a/nanomesh/image/_base.py
+++ b/nanomesh/image/_base.py
@@ -24,8 +24,8 @@ def _normalize_values(image: np.ndarray):
     return out
 
 
-@doc(prefix='Base class for image data', shape='')
-class BaseImage(object, metaclass=DocFormatterMeta):
+@doc(prefix='Generic image class', shape='')
+class GenericImage(object, metaclass=DocFormatterMeta):
     """{prefix}.
 
     Parameters
@@ -95,7 +95,7 @@ class BaseImage(object, metaclass=DocFormatterMeta):
         return sitk.GetImageFromArray(self.image)
 
     @classmethod
-    def from_sitk_image(cls, sitk_image) -> 'BaseImage':
+    def from_sitk_image(cls, sitk_image) -> 'GenericImage':
         """Return instance from :class:`SimpleITK.Image`."""
         import SimpleITK as sitk
         image = sitk.GetArrayFromImage(sitk_image)
@@ -266,7 +266,7 @@ class BaseImage(object, metaclass=DocFormatterMeta):
 
         return self.apply(func, **kwargs)
 
-    def fft(self) -> 'BaseImage':
+    def fft(self) -> 'GenericImage':
         """Apply fourier transform to image.
 
         Returns

--- a/nanomesh/image/_plane.py
+++ b/nanomesh/image/_plane.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from .._doc import doc
-from ._base import BaseImage
+from ._base import GenericImage
 from ._utils import show_image
 
 logger = logging.getLogger(__name__)
@@ -17,10 +17,10 @@ if TYPE_CHECKING:
     from .mesh import TriangleMesh
 
 
-@doc(BaseImage,
+@doc(GenericImage,
      prefix='Data class for working with 2D image data',
      shape='(i,j) ')
-class Plane(BaseImage):
+class Plane(GenericImage):
 
     @classmethod
     def load(cls, filename: os.PathLike, **kwargs) -> Plane:

--- a/nanomesh/image/_volume.py
+++ b/nanomesh/image/_volume.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .._doc import doc
 from ..io import load_vol
-from ._base import BaseImage
+from ._base import GenericImage
 from ._plane import Plane
 
 if TYPE_CHECKING:
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@doc(BaseImage,
-     prefix='Data class for working with 3D (volumetric) image data',
+@doc(GenericImage,
+     prefix='Generic class for working with 3D (volumetric) image data',
      shape='(i,j,k) ')
-class Volume(BaseImage):
+class Volume(GenericImage):
 
     @classmethod
     def load(cls, filename: os.PathLike, **kwargs) -> 'Volume':

--- a/nanomesh/image2mesh/_base.py
+++ b/nanomesh/image2mesh/_base.py
@@ -8,13 +8,13 @@ import numpy as np
 
 from .._doc import doc
 from ..image import Plane, Volume
-from ..mesh._base import BaseMesh
+from ..mesh._base import GenericMesh
 
 logger = logging.getLogger(__name__)
 
 
 @doc(prefix='mesh from image data')
-class BaseMesher(ABC):
+class AbstractMesher(ABC):
     """Utility class to generate a {prefix}.
 
     Parameters
@@ -28,7 +28,7 @@ class BaseMesher(ABC):
         Reference to image data
     image_orig : numpy.ndarray
         Keep reference to original image data
-    contour : BaseMesh
+    contour : GenericMesh
         Stores the contour mesh.
     """
 
@@ -36,7 +36,7 @@ class BaseMesher(ABC):
         if isinstance(image, (Plane, Volume)):
             image = image.image
 
-        self.contour: BaseMesh | None = None
+        self.contour: GenericMesh | None = None
         self.image_orig = image
         self.image = image
 

--- a/nanomesh/image2mesh/mesher2d/_mesher.py
+++ b/nanomesh/image2mesh/mesher2d/_mesher.py
@@ -10,7 +10,7 @@ from skimage import measure
 from nanomesh._doc import doc
 from nanomesh.region_markers import RegionMarker
 
-from .._base import BaseMesher
+from .._base import AbstractMesher
 from ._helpers import append_to_segment_markers, generate_segment_markers, pad
 from ._polygon import Polygon
 
@@ -160,8 +160,8 @@ def _generate_segments(polygons: List[Polygon]) -> np.ndarray:
     return np.vstack(segments)
 
 
-@doc(BaseMesher, prefix='triangular mesh from 2D image data')
-class Mesher2D(BaseMesher):
+@doc(AbstractMesher, prefix='triangular mesh from 2D image data')
+class Mesher2D(AbstractMesher):
 
     def __init__(self, image: np.ndarray | Plane):
         super().__init__(image)

--- a/nanomesh/image2mesh/mesher3d/_mesher.py
+++ b/nanomesh/image2mesh/mesher3d/_mesher.py
@@ -11,7 +11,7 @@ from nanomesh._doc import doc
 from nanomesh.mesh import TriangleMesh
 from nanomesh.region_markers import RegionMarker, RegionMarkerLike
 
-from .._base import BaseMesher
+from .._base import AbstractMesher
 from ._bounding_box import BoundingBox
 from ._helpers import pad
 
@@ -227,8 +227,8 @@ def generate_envelope(mesh: TriangleMesh,
     return mesh
 
 
-@doc(BaseMesher, prefix='tetrahedral mesh from 3D (volumetric) image data')
-class Mesher3D(BaseMesher):
+@doc(AbstractMesher, prefix='tetrahedral mesh from 3D (volumetric) image data')
+class Mesher3D(AbstractMesher):
 
     def __init__(self, image: np.ndarray):
         super().__init__(image)

--- a/nanomesh/mesh/__init__.py
+++ b/nanomesh/mesh/__init__.py
@@ -1,4 +1,4 @@
-from ._base import registry
+from ._base import GenericMesh, registry
 from ._line import LineMesh
 from ._tetra import TetraMesh
 from ._triangle import TriangleMesh
@@ -8,7 +8,8 @@ for _mesh_class in (LineMesh, TriangleMesh, TetraMesh):
 
 __all__ = [
     'LineMesh',
+    'GenericMesh',
+    'registry',
     'TetraMesh',
     'TriangleMesh',
-    'registry',
 ]

--- a/nanomesh/mesh/_base.py
+++ b/nanomesh/mesh/_base.py
@@ -13,8 +13,8 @@ from ..region_markers import RegionMarker, RegionMarkerLike
 registry: Dict[str, Any] = {}
 
 
-@doc(prefix='Base class for meshes', dim_points='n', dim_cells='j')
-class BaseMesh(object, metaclass=DocFormatterMeta):
+@doc(prefix='Generic mesh class', dim_points='n', dim_cells='j')
+class GenericMesh(object, metaclass=DocFormatterMeta):
     """{prefix}.
 
     Parameters
@@ -131,7 +131,7 @@ class BaseMesh(object, metaclass=DocFormatterMeta):
             key = key.replace(':ref', '-ref')
             cell_data[key] = value[0]
 
-        return BaseMesh.create(points=points, cells=cells, **cell_data)
+        return GenericMesh.create(points=points, cells=cells, **cell_data)
 
     @classmethod
     def create(cls, points, cells, **cell_data):
@@ -167,10 +167,14 @@ class BaseMesh(object, metaclass=DocFormatterMeta):
         return pv.from_meshio(self.to_meshio())
 
     def plot(self, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f'Not implemented for {self.__class__.__name__}, '
+            'use one of the specific subclasses.')
 
     def plot_mpl(self, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f'Not implemented for {self.__class__.__name__}, '
+            'use one of the specific subclasses.')
 
     def plot_itk(self, **kwargs):
         """Wrapper for :func:`pyvista.plot_itk`.

--- a/nanomesh/mesh/_line.py
+++ b/nanomesh/mesh/_line.py
@@ -6,17 +6,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from .._doc import doc
-from ._base import BaseMesh
+from ._base import GenericMesh
 
 if TYPE_CHECKING:
     from ..mesh_container import MeshContainer
 
 
-@doc(BaseMesh,
+@doc(GenericMesh,
      prefix='Data class for line meshes',
      dim_points='2 or 3',
      dim_cells='2')
-class LineMesh(BaseMesh):
+class LineMesh(GenericMesh):
     cell_type = 'line'
 
     def plot_mpl(self, *args, **kwargs) -> plt.Axes:

--- a/nanomesh/mesh/_tetra.py
+++ b/nanomesh/mesh/_tetra.py
@@ -4,14 +4,14 @@ import numpy as np
 import pyvista as pv
 
 from .._doc import doc
-from ._base import BaseMesh
+from ._base import GenericMesh
 
 
-@doc(BaseMesh,
+@doc(GenericMesh,
      prefix='Data class for tetrahedral meshes',
      dim_points='3',
      dim_cells='4')
-class TetraMesh(BaseMesh):
+class TetraMesh(GenericMesh):
     cell_type = 'tetra'
 
     def to_open3d(self):

--- a/nanomesh/mesh/_triangle.py
+++ b/nanomesh/mesh/_triangle.py
@@ -9,7 +9,7 @@ import scipy
 
 from .._doc import doc
 from .._tetgen_wrapper import tetrahedralize
-from ._base import BaseMesh
+from ._base import GenericMesh
 from ._mixin import PruneZ0Mixin
 
 if TYPE_CHECKING:
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
     from nanomesh import MeshContainer
 
 
-@doc(BaseMesh,
+@doc(GenericMesh,
      prefix='Data class for triangle meshes',
      dim_points='2 or 3',
      dim_cells='3')
-class TriangleMesh(BaseMesh, PruneZ0Mixin):
+class TriangleMesh(GenericMesh, PruneZ0Mixin):
     cell_type = 'triangle'
 
     def plot(self, **kwargs):

--- a/nanomesh/mesh_container.py
+++ b/nanomesh/mesh_container.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 import meshio
 import numpy as np
 
-from .mesh._base import BaseMesh
+from .mesh._base import GenericMesh
 from .mesh._mixin import PruneZ0Mixin
 
 
@@ -175,7 +175,7 @@ class MeshContainer(meshio.Mesh, PruneZ0Mixin):
 
         Returns
         -------
-        BaseMesh
+        GenericMesh
             Mesh of the given type
         """
         if not cell_type:
@@ -194,10 +194,10 @@ class MeshContainer(meshio.Mesh, PruneZ0Mixin):
 
         fields = self.field_to_number.get(cell_type, None)
 
-        return BaseMesh.create(cells=cells,
-                               points=points,
-                               fields=fields,
-                               **cell_data)
+        return GenericMesh.create(cells=cells,
+                                  points=points,
+                                  fields=fields,
+                                  **cell_data)
 
     def get_all_cell_data(self, cell_type: str = None) -> dict:
         """Get all cell data for given `cell_type`.
@@ -281,14 +281,15 @@ class MeshContainer(meshio.Mesh, PruneZ0Mixin):
         return mesh.plot_pyvista(**kwargs)
 
     @classmethod
-    def from_mesh(cls, mesh: BaseMesh):
-        """Convert from :class:`nanomesh.mesh._base.BaseMesh` to
+    def from_mesh(cls, mesh: GenericMesh):
+        """Convert from :class:`nanomesh.mesh.GenericMesh` to
         :class:`MeshContainer`.
 
         Parameters
         ----------
-        mesh : BaseMesh
-            Input mesh, must be a subclass of `BaseMesh`.
+        mesh : Mesh
+            Input mesh, must be a subclass of
+            :class:`nanomesh.mesh.GenericMesh`.
 
         Returns
         -------

--- a/nanomesh/metrics.py
+++ b/nanomesh/metrics.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Tuple
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .mesh._base import BaseMesh
+from .mesh._base import GenericMesh
 
 
 class Metric:
@@ -23,7 +23,7 @@ class Metric:
         super().__init__()
         self.metric = metric
 
-    def __call__(self, mesh: BaseMesh) -> np.ndarray:
+    def __call__(self, mesh: GenericMesh) -> np.ndarray:
         grid = mesh.to_pyvista_unstructured_grid()
         ret = grid.compute_cell_quality(self.metric)
         quality = ret.cell_data['CellQuality']
@@ -64,7 +64,7 @@ shape = Metric('shape')
 shape_and_size = Metric('shape_and_size')
 
 
-def max_min_edge_ratio(mesh: BaseMesh) -> np.ndarray:
+def max_min_edge_ratio(mesh: GenericMesh) -> np.ndarray:
     """Place holder, updated dynamically."""
     cell_points = mesh.points[mesh.cells]
     diff = cell_points - np.roll(cell_points, shift=1, axis=1)
@@ -229,7 +229,7 @@ for descriptor in _metric_dispatch.values():
 
 Parameters
 ----------
-mesh : BaseMesh
+mesh : GenericMesh
     Input mesh
 
 Returns
@@ -239,15 +239,15 @@ quality : numpy.ndarray
     """
 
 
-def calculate_all_metrics(mesh: BaseMesh, inplace: bool = False) -> dict:
+def calculate_all_metrics(mesh: GenericMesh, inplace: bool = False) -> dict:
     """Calculate all available metrics.
 
     Parameters
     ----------
-    mesh : BaseMesh
+    mesh : GenericMesh
         Input mesh
     inplace : bool, optional
-        Updates the :attr:`BaseMesh.cell_data` attribute on the mesh with
+        Updates the :attr:`GenericMesh.cell_data` attribute on the mesh with
         the metrics.
 
     Returns
@@ -267,7 +267,7 @@ def calculate_all_metrics(mesh: BaseMesh, inplace: bool = False) -> dict:
 
 
 def histogram(
-    mesh: BaseMesh,
+    mesh: GenericMesh,
     *,
     metric: str,
     ax: plt.Axes = None,
@@ -277,7 +277,7 @@ def histogram(
 
     Parameters
     ----------
-    mesh : BaseMesh
+    mesh : GenericMesh
         Input mesh
     metric : str
         Metric to calculate.
@@ -317,7 +317,7 @@ def histogram(
 
 
 def plot2d(
-    mesh: BaseMesh,
+    mesh: GenericMesh,
     *,
     metric: str,
     ax: plt.Axes = None,
@@ -327,7 +327,7 @@ def plot2d(
 
     Parameters
     ----------
-    mesh : BaseMesh
+    mesh : GenericMesh
         Input mesh
     metric : str
         Metric to calculate.

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -3,7 +3,7 @@ import pytest
 import pyvista as pv
 
 from nanomesh.mesh import TriangleMesh
-from nanomesh.mesh._base import BaseMesh
+from nanomesh.mesh._base import GenericMesh
 
 
 @pytest.mark.parametrize('n_points,n_cells,expected', (
@@ -16,7 +16,7 @@ def test_create(n_points, n_cells, expected):
     points = np.arange(5 * n_points).reshape(5, n_points)
     cells = np.zeros((5, n_cells))
 
-    mesh = BaseMesh.create(points=points, cells=cells)
+    mesh = GenericMesh.create(points=points, cells=cells)
 
     assert mesh.cell_type == expected
 


### PR DESCRIPTION
Rename base types to better reflect their purpose.

```
`BaseImage` -> `GenericImage`
`BaseMesh` -> `GenericMesh`
`BaseMesher` -> `AbstractMesher`
```

Closes #222