### PR TITLE
Use `__init_subclass__` to create registry for derived classes

### DIFF
--- a/nanomesh/_doc.py
+++ b/nanomesh/_doc.py
@@ -29,11 +29,15 @@ class DocFormatterMeta(type):
     Updates instances of `{classname}` to `classname`.
     """
 
-    def __new__(mcls, classname, bases, cls_dict):
-        cls = super().__new__(mcls, classname, bases, cls_dict)
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        return cls
+
+    def __new__(mcls, classname, bases, cls_dict, **kwargs):
+        cls = super().__new__(mcls, classname, bases, cls_dict, **kwargs)
 
         for name, method in inspect.getmembers(cls):
-            is_private = name.startswith('_')
+            is_private = name.startswith('__')
             is_none = (not method) or (not method.__doc__)
 
             if any((is_private, is_none)):

--- a/nanomesh/image/_base.py
+++ b/nanomesh/image/_base.py
@@ -1,6 +1,6 @@
 import operator
 import os
-from typing import Callable, Union
+from typing import Any, Callable, Dict, Union
 
 import numpy as np
 
@@ -25,8 +25,7 @@ def _normalize_values(image: np.ndarray):
 
 
 @doc(prefix='Generic image class', shape='')
-# class GenericImage(object, metaclass=DocFormatterMeta):
-class GenericImage:
+class GenericImage(object, metaclass=DocFormatterMeta):
     """{prefix}.
 
     Parameters
@@ -39,7 +38,7 @@ class GenericImage:
     image : {shape}numpy.ndarray
         The raw image data
     """
-    _registry = {}
+    _registry: Dict[int, Any] = {}
 
     def __init_subclass__(cls, ndim: int, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -47,9 +46,7 @@ class GenericImage:
 
     def __new__(cls, image: np.ndarray):
         subclass = cls._registry.get(image.ndim, cls)
-        obj = object.__new__(subclass)
-        obj.__init__(image)
-        return obj
+        return super().__new__(subclass)
 
     def __init__(self, image: np.ndarray):
         self.image = image

--- a/nanomesh/image/_base.py
+++ b/nanomesh/image/_base.py
@@ -47,7 +47,9 @@ class GenericImage:
 
     def __new__(cls, image: np.ndarray):
         subclass = cls._registry.get(image.ndim, cls)
-        return subclass
+        obj = object.__new__(subclass)
+        obj.__init__(image)
+        return obj
 
     def __init__(self, image: np.ndarray):
         self.image = image

--- a/nanomesh/image/_base.py
+++ b/nanomesh/image/_base.py
@@ -25,7 +25,8 @@ def _normalize_values(image: np.ndarray):
 
 
 @doc(prefix='Generic image class', shape='')
-class GenericImage(object, metaclass=DocFormatterMeta):
+# class GenericImage(object, metaclass=DocFormatterMeta):
+class GenericImage:
     """{prefix}.
 
     Parameters
@@ -38,6 +39,15 @@ class GenericImage(object, metaclass=DocFormatterMeta):
     image : {shape}numpy.ndarray
         The raw image data
     """
+    _registry = {}
+
+    def __init_subclass__(cls, ndim: int, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._registry[ndim] = cls
+
+    def __new__(cls, image: np.ndarray):
+        subclass = cls._registry.get(image.ndim, cls)
+        return subclass
 
     def __init__(self, image: np.ndarray):
         self.image = image

--- a/nanomesh/image/_plane.py
+++ b/nanomesh/image/_plane.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @doc(GenericImage,
      prefix='Data class for working with 2D image data',
      shape='(i,j) ')
-class Plane(GenericImage):
+class Plane(GenericImage, ndim=2):
 
     @classmethod
     def load(cls, filename: os.PathLike, **kwargs) -> Plane:

--- a/nanomesh/image/_volume.py
+++ b/nanomesh/image/_volume.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @doc(GenericImage,
      prefix='Generic class for working with 3D (volumetric) image data',
      shape='(i,j,k) ')
-class Volume(GenericImage):
+class Volume(GenericImage, ndim=3):
 
     @classmethod
     def load(cls, filename: os.PathLike, **kwargs) -> 'Volume':

--- a/nanomesh/image2mesh/_base.py
+++ b/nanomesh/image2mesh/_base.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @doc(prefix='mesh from image data')
-class AbstractMesher(ABC):
+class AbstractMesher:
     """Utility class to generate a {prefix}.
 
     Parameters
@@ -31,6 +31,18 @@ class AbstractMesher(ABC):
     contour : GenericMesh
         Stores the contour mesh.
     """
+    _registry = {}
+
+    def __init_subclass__(cls, ndim, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._registry[ndim] = cls
+
+    def __new__(cls, image):
+        ndim = image.ndim
+        subclass = cls._registry.get(ndim, cls)
+        obj = object.__new__(subclass)
+        obj.__init__(image)
+        return obj
 
     def __init__(self, image: Union[np.ndarray, Plane, Volume]):
         if isinstance(image, (Plane, Volume)):

--- a/nanomesh/image2mesh/_base.py
+++ b/nanomesh/image2mesh/_base.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
-from typing import Union
+from abc import abstractmethod
+from typing import Any, Dict, Union
 
 import numpy as np
 
@@ -31,18 +31,16 @@ class AbstractMesher:
     contour : GenericMesh
         Stores the contour mesh.
     """
-    _registry = {}
+    _registry: Dict[int, Any] = {}
 
-    def __init_subclass__(cls, ndim, **kwargs):
+    def __init_subclass__(cls, ndim: int, **kwargs):
         super().__init_subclass__(**kwargs)
         cls._registry[ndim] = cls
 
-    def __new__(cls, image):
+    def __new__(cls, image: np.ndarray):
         ndim = image.ndim
         subclass = cls._registry.get(ndim, cls)
-        obj = object.__new__(subclass)
-        obj.__init__(image)
-        return obj
+        return super().__new__(subclass)
 
     def __init__(self, image: Union[np.ndarray, Plane, Volume]):
         if isinstance(image, (Plane, Volume)):

--- a/nanomesh/image2mesh/_base.py
+++ b/nanomesh/image2mesh/_base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Union
 import numpy as np
 
 from .._doc import doc
-from ..image import Plane, Volume
+from ..image import GenericImage
 from ..mesh._base import GenericMesh
 
 logger = logging.getLogger(__name__)
@@ -37,13 +37,15 @@ class AbstractMesher:
         super().__init_subclass__(**kwargs)
         cls._registry[ndim] = cls
 
-    def __new__(cls, image: np.ndarray):
+    def __new__(cls, image: Union[np.ndarray, GenericImage]):
+        if isinstance(image, GenericImage):
+            image = image.image
         ndim = image.ndim
         subclass = cls._registry.get(ndim, cls)
         return super().__new__(subclass)
 
-    def __init__(self, image: Union[np.ndarray, Plane, Volume]):
-        if isinstance(image, (Plane, Volume)):
+    def __init__(self, image: Union[np.ndarray, GenericImage]):
+        if isinstance(image, GenericImage):
             image = image.image
 
         self.contour: GenericMesh | None = None
@@ -52,10 +54,11 @@ class AbstractMesher:
 
     def __repr__(self):
         """Canonical string representation."""
+        contour_str = self.contour.__repr__(indent=4) if self.contour else None
         s = (
             f'{self.__class__.__name__}(',
             f'    image = {self.image!r},',
-            f'    contour = {self.contour.__repr__(indent=4)}'
+            f'    contour = {contour_str}'
             ')',
         )
         return '\n'.join(s)

--- a/nanomesh/image2mesh/mesher2d/_mesher.py
+++ b/nanomesh/image2mesh/mesher2d/_mesher.py
@@ -153,7 +153,7 @@ def _generate_segments(polygons: List[Polygon]) -> np.ndarray:
 
 
 @doc(AbstractMesher, prefix='triangular mesh from 2D image data')
-class Mesher2D(AbstractMesher):
+class Mesher2D(AbstractMesher, ndim=2):
 
     def __init__(self, image: np.ndarray | Plane):
         super().__init__(image)

--- a/nanomesh/image2mesh/mesher3d/_mesher.py
+++ b/nanomesh/image2mesh/mesher3d/_mesher.py
@@ -227,7 +227,7 @@ def generate_envelope(mesh: TriangleMesh,
 
 
 @doc(AbstractMesher, prefix='tetrahedral mesh from 3D (volumetric) image data')
-class Mesher3D(AbstractMesher):
+class Mesher3D(AbstractMesher, ndim=3):
 
     def __init__(self, image: np.ndarray):
         super().__init__(image)

--- a/nanomesh/mesh/__init__.py
+++ b/nanomesh/mesh/__init__.py
@@ -1,10 +1,7 @@
-from ._base import GenericMesh, registry
+from ._base import GenericMesh
 from ._line import LineMesh
 from ._tetra import TetraMesh
 from ._triangle import TriangleMesh
-
-for _mesh_class in (LineMesh, TriangleMesh, TetraMesh):
-    registry[_mesh_class.cell_type] = _mesh_class
 
 __all__ = [
     'LineMesh',

--- a/nanomesh/mesh/_base.py
+++ b/nanomesh/mesh/_base.py
@@ -14,7 +14,8 @@ registry: Dict[str, Any] = {}
 
 
 @doc(prefix='Generic mesh class', dim_points='n', dim_cells='j')
-class GenericMesh(object, metaclass=DocFormatterMeta):
+# class GenericMesh(object, metaclass=DocFormatterMeta):
+class GenericMesh:
     """{prefix}.
 
     Parameters
@@ -32,11 +33,24 @@ class GenericMesh(object, metaclass=DocFormatterMeta):
         Additional cell data. Argument must be a 1D numpy array
         matching the number of cells defined by `i`.
     """
+    _registry = {}
     cell_type: str = 'base'
+
+    def __init_subclass__(cls, cell_dim: int, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._registry[cell_dim] = cls
+
+    def __new__(cls, points, cells, *args, **kwargs):
+        cell_dim = cells.shape[1]
+        subclass = cls._registry.get(cell_dim, cls)
+        obj = object.__new__(subclass)
+        obj.__init__(points, cells, *args, **kwargs)
+        return obj
 
     def __init__(self,
                  points: np.ndarray,
                  cells: np.ndarray,
+                 *,
                  fields: Dict[str, int] = None,
                  region_markers: RegionMarkerList = None,
                  **cell_data):

--- a/nanomesh/mesh/_line.py
+++ b/nanomesh/mesh/_line.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
      prefix='Data class for line meshes',
      dim_points='2 or 3',
      dim_cells='2')
-class LineMesh(GenericMesh):
+class LineMesh(GenericMesh, cell_dim=2):
     cell_type = 'line'
 
     def plot_mpl(self, *args, **kwargs) -> plt.Axes:

--- a/nanomesh/mesh/_tetra.py
+++ b/nanomesh/mesh/_tetra.py
@@ -11,7 +11,7 @@ from ._base import GenericMesh
      prefix='Data class for tetrahedral meshes',
      dim_points='3',
      dim_cells='4')
-class TetraMesh(GenericMesh):
+class TetraMesh(GenericMesh, cell_dim=4):
     cell_type = 'tetra'
 
     def to_open3d(self):

--- a/nanomesh/mesh/_triangle.py
+++ b/nanomesh/mesh/_triangle.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
      prefix='Data class for triangle meshes',
      dim_points='2 or 3',
      dim_cells='3')
-class TriangleMesh(GenericMesh, PruneZ0Mixin):
+class TriangleMesh(GenericMesh, PruneZ0Mixin, cell_dim=3):
     cell_type = 'triangle'
 
     def plot(self, **kwargs):

--- a/nanomesh/mesh_container.py
+++ b/nanomesh/mesh_container.py
@@ -194,10 +194,10 @@ class MeshContainer(meshio.Mesh, PruneZ0Mixin):
 
         fields = self.field_to_number.get(cell_type, None)
 
-        return GenericMesh.create(cells=cells,
-                                  points=points,
-                                  fields=fields,
-                                  **cell_data)
+        return GenericMesh(cells=cells,
+                           points=points,
+                           fields=fields,
+                           **cell_data)
 
     def get_all_cell_data(self, cell_type: str = None) -> dict:
         """Get all cell data for given `cell_type`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def line_mesh():
     cells = np.zeros((5, 2), dtype=int)
     cell_data = {LABEL_KEY: np.arange(5)}
 
-    mesh = LineMesh.create(cells=cells, points=points, **cell_data)
+    mesh = LineMesh(cells=cells, points=points, **cell_data)
     mesh.default_key = LABEL_KEY
     assert isinstance(mesh, LineMesh)
     return mesh
@@ -40,7 +40,7 @@ def triangle_mesh_2d():
     cells = np.zeros((5, 3), dtype=int)
     cell_data = {LABEL_KEY: np.arange(5)}
 
-    mesh = TriangleMesh.create(cells=cells, points=points, **cell_data)
+    mesh = TriangleMesh(cells=cells, points=points, **cell_data)
     mesh.default_key = LABEL_KEY
     assert isinstance(mesh, TriangleMesh)
     return mesh
@@ -52,7 +52,7 @@ def triangle_mesh_3d():
     cells = np.zeros((5, 3), dtype=int)
     cell_data = {LABEL_KEY: np.arange(5)}
 
-    mesh = TriangleMesh.create(cells=cells, points=points, **cell_data)
+    mesh = TriangleMesh(cells=cells, points=points, **cell_data)
     mesh.default_key = LABEL_KEY
     assert isinstance(mesh, TriangleMesh)
     return mesh
@@ -64,7 +64,7 @@ def tetra_mesh():
     cells = np.zeros((5, 4), dtype=int)
     cell_data = {LABEL_KEY: np.arange(5)}
 
-    mesh = TetraMesh.create(cells=cells, points=points, **cell_data)
+    mesh = TetraMesh(cells=cells, points=points, **cell_data)
     assert isinstance(mesh, TetraMesh)
     return mesh
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -16,7 +16,7 @@ def test_create(n_points, n_cells, expected):
     points = np.arange(5 * n_points).reshape(5, n_points)
     cells = np.zeros((5, n_cells))
 
-    mesh = GenericMesh.create(points=points, cells=cells)
+    mesh = GenericMesh(points=points, cells=cells)
 
     assert mesh.cell_type == expected
 

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from nanomesh import (LineMesh, Mesher2D, Mesher3D, Plane, TetraMesh,
+                      TriangleMesh, Volume)
+from nanomesh.image import GenericImage
+from nanomesh.image2mesh import GenericMesher
+from nanomesh.mesh import GenericMesh
+
+
+@pytest.mark.parametrize('data,instance', (
+    (np.arange(24), GenericImage),
+    (np.arange(24).reshape(4, 6), Plane),
+    (np.arange(24).reshape(4, 3, 2), Volume),
+))
+def test_image_subclassing(data, instance):
+    image = GenericImage(data)
+    assert isinstance(image, instance)
+
+
+@pytest.mark.parametrize('data,instance', (
+    (1, GenericImage),
+    (1, Plane),
+    (1, Volume),
+))
+def test_mesh_subclassing(data, instance):
+    image = GenericMesh(data)
+    assert isinstance(image, instance)
+
+
+@pytest.mark.parametrize('data,instance', (
+    (1, Mesher2D),
+    (1, Mesher3D),
+))
+def test_mesher_subclassing(data, instance):
+    image = GenericMesher(data)
+    assert isinstance(image, instance)

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -4,14 +4,49 @@ import pytest
 from nanomesh import (LineMesh, Mesher2D, Mesher3D, Plane, TetraMesh,
                       TriangleMesh, Volume)
 from nanomesh.image import GenericImage
-from nanomesh.image2mesh import GenericMesher
+from nanomesh.image2mesh._base import AbstractMesher as GenericMesher
 from nanomesh.mesh import GenericMesh
+
+im1d = np.arange(24)
+im2d = np.arange(24).reshape(6, 4)
+im3d = np.arange(24).reshape(3, 4, 2)
+
+points = np.array((
+    (1, 0, 0),
+    (0, 1, 0),
+    (0, 0, 1),
+    (1, 1, 1),
+))
+
+lines = np.array((
+    (0, 1),
+    (1, 2),
+    (2, 3),
+))
+
+triangles = np.array((
+    (0, 1, 2),
+    (1, 2, 3),
+    (3, 0, 1),
+))
+
+tetras = np.array((
+    (0, 1, 2, 3),
+    (3, 2, 1, 0),
+))
+
+other = np.array((
+    (0, ),
+    (1, ),
+    (2, ),
+    (3, ),
+))
 
 
 @pytest.mark.parametrize('data,instance', (
-    (np.arange(24), GenericImage),
-    (np.arange(24).reshape(4, 6), Plane),
-    (np.arange(24).reshape(4, 3, 2), Volume),
+    (im1d, GenericImage),
+    (im2d, Plane),
+    (im3d, Volume),
 ))
 def test_image_subclassing(data, instance):
     image = GenericImage(data)
@@ -19,19 +54,22 @@ def test_image_subclassing(data, instance):
 
 
 @pytest.mark.parametrize('data,instance', (
-    (1, GenericImage),
-    (1, Plane),
-    (1, Volume),
+    ((points, other), GenericMesh),
+    ((points, lines), LineMesh),
+    ((points, triangles), TriangleMesh),
+    ((points, tetras), TetraMesh),
 ))
 def test_mesh_subclassing(data, instance):
-    image = GenericMesh(data)
-    assert isinstance(image, instance)
+    mesh = GenericMesh(*data)
+    assert isinstance(mesh, instance)
 
 
-@pytest.mark.parametrize('data,instance', (
-    (1, Mesher2D),
-    (1, Mesher3D),
-))
-def test_mesher_subclassing(data, instance):
-    image = GenericMesher(data)
-    assert isinstance(image, instance)
+# @pytest.mark.parametrize('data,instance', (
+#     (im2d, Mesher2D),
+#     (Plane(im2d, Mesher2D),
+#     (im3d), Mesher3D),
+#     (Volume(im3d), Mesher3D),
+# ))
+# def test_mesher_subclassing(data, instance):
+#     image = GenericMesher(data)
+#     assert isinstance(image, instance)

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -46,6 +46,7 @@ other = np.array((
 @pytest.mark.parametrize('data,instance', (
     (im1d, GenericImage),
     (im2d, Plane),
+    (im2d, Plane),
     (im3d, Volume),
 ))
 def test_image_subclassing(data, instance):
@@ -64,12 +65,12 @@ def test_mesh_subclassing(data, instance):
     assert isinstance(mesh, instance)
 
 
-# @pytest.mark.parametrize('data,instance', (
-#     (im2d, Mesher2D),
-#     (Plane(im2d, Mesher2D),
-#     (im3d), Mesher3D),
-#     (Volume(im3d), Mesher3D),
-# ))
-# def test_mesher_subclassing(data, instance):
-#     image = GenericMesher(data)
-#     assert isinstance(image, instance)
+@pytest.mark.parametrize('data,instance', (
+    (im2d, Mesher2D),
+    (Plane(im2d), Mesher2D),
+    (im3d, Mesher3D),
+    (Volume(im3d), Mesher3D),
+))
+def test_mesher_subclassing(data, instance):
+    image = GenericMesher(data)
+    assert isinstance(image, instance)


### PR DESCRIPTION
This PR enables this:

```python
from nanomesh.image import GenericImage, Plane
import numpy as np

image = np.arange(5,5).reshape(5,5)
plane = GenericImage(image)
assert isinstance(plane, Plane)
```

This makes it easier to instantiate the correct class.

