### PR TITLE
Refactor triangulate

### DIFF
--- a/docs/api.helpers.rst
+++ b/docs/api.helpers.rst
@@ -20,6 +20,7 @@ stores metadata about a region in a mesh. :func:`tetrahedralize` and
 .. autosummary::
 
    nanomesh.tetrahedralize
+   nanomesh.simple_triangulate
    nanomesh.triangulate
 
 Reference

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,7 @@ and functions listed below. See the :ref:`examples` for how to use them.
 
 .. autosummary::
 
+   nanomesh.simple_triangulate
    nanomesh.triangulate
    nanomesh.tetrahedralize
    nanomesh.volume2mesh

--- a/nanomesh/__init__.py
+++ b/nanomesh/__init__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from ._tetgen_wrapper import tetrahedralize
-from ._triangle_wrapper import triangulate
+from ._triangle_wrapper import simple_triangulate, triangulate
 from .image import Image, Plane, Volume
 from .image2mesh import Mesher, Mesher2D, Mesher3D, plane2mesh, volume2mesh
 from .mesh import LineMesh, Mesh, TetraMesh, TriangleMesh
@@ -32,6 +32,7 @@ __all__ = [
     'plane2mesh',
     'RegionMarker',
     'RegionMarkerList',
+    'simple_triangulate',
     'tetrahedralize',
     'TetraMesh',
     'TriangleMesh',

--- a/nanomesh/_tetgen_wrapper.py
+++ b/nanomesh/_tetgen_wrapper.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Tuple
 
 from ._doc import doc
 from .region_markers import RegionMarkerList
+from .utils import _to_opts_string
 
 if TYPE_CHECKING:
     from .mesh import TriangleMesh
@@ -108,7 +109,9 @@ def call_tetgen(fname: os.PathLike, opts: str = '-pAq'):
 
 
 @doc(prefix='Tetrahedralize a surface mesh')
-def tetrahedralize(mesh: TriangleMesh, opts: str = '-pAq') -> MeshContainer:
+def tetrahedralize(mesh: TriangleMesh,
+                   opts: str | dict = '-pAq',
+                   default_opts: dict = None) -> MeshContainer:
     """{prefix}.
 
     Parameters
@@ -128,12 +131,19 @@ def tetrahedralize(mesh: TriangleMesh, opts: str = '-pAq') -> MeshContainer:
         - `-q`: Refines mesh (to improve mesh quality).
         - `-a`: Applies a maximum tetrahedron volume constraint.
 
+        Can be passed as a raw string, `opts='-pAq1.2', or dict,
+        `opts=dict('p'= True, 'A'= True, 'q'=1.2)`.
+    default_opts : dict, optional
+        Dictionary with default options. These will be merged with `opts`.
+
     Returns
     -------
     MeshContainer
         Tetrahedralized mesh.
     """
     from .mesh_container import MeshContainer
+
+    opts = _to_opts_string(opts, defaults=default_opts, prefix='-', sep=' ')
 
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp, 'nanomesh.smesh')

--- a/nanomesh/_triangle_wrapper.py
+++ b/nanomesh/_triangle_wrapper.py
@@ -1,34 +1,44 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 import triangle as tr
 
 from ._doc import doc
 from .mesh_container import MeshContainer
+from .utils import _to_opts_string
 
 if TYPE_CHECKING:
     from nanomesh import LineMesh
 
 
 @doc(prefix='Triangulate a contour mesh')
-def triangulate(mesh: LineMesh, opts: str = '') -> MeshContainer:
+def triangulate(mesh: LineMesh,
+                opts: Optional[str | dict] = None,
+                default_opts: dict = None) -> MeshContainer:
     """{prefix}.
 
     Parameters
     ----------
     mesh : LineMesh
         Input contour mesh
-    opts : str, optional
-        Additional options passed to `triangle.triangulate` documented here:
+    opts : str | dict, optional
+        Triangulation options passed to `triangle.triangulate` documented here:
         https://rufat.be/triangle/API.html#triangle.triangulate
+
+        Can be passed as a raw string, `opts='pAq30', or dict,
+        `opts=dict('p'= True, 'A'= True, 'q'=30)`.
+    default_opts : dict, optional
+        Dictionary with default options. These will be merged with `opts`.
 
     Returns
     -------
     mesh : MeshContainer
         Triangulated 2D mesh.
     """
+    opts = _to_opts_string(opts, defaults=default_opts)
+
     points = mesh.points
     segments = mesh.cells
     regions = [(m.point[0], m.point[1], m.label, m.constraint)
@@ -56,7 +66,7 @@ def simple_triangulate(points: np.ndarray,
                        regions: Sequence[Tuple[float, float, int,
                                                float, ]] = None,
                        segment_markers: np.ndarray = None,
-                       opts: str = '') -> MeshContainer:
+                       opts: str = None) -> MeshContainer:
     """Simple triangulation using :mod:`triangle`.
 
     Parameters
@@ -77,9 +87,12 @@ def simple_triangulate(points: np.ndarray,
         number the maximum area constraint for the region.
     segment_markers : (j,1) numpy.ndarray, optional
         Array with labels for segments.
-    opts : str, optional
+    opts : str | dict, optional
         Additional options passed to `triangle.triangulate` documented here:
         https://rufat.be/triangle/API.html#triangle.triangulate
+
+        Can be passed as a raw string, `opts='pAq30', or dict,
+        `opts=dict('p'= True, 'A'= True, 'q'=30)`.
 
     Returns
     -------
@@ -87,6 +100,8 @@ def simple_triangulate(points: np.ndarray,
         Triangulated 2D mesh
     """
     from nanomesh import MeshContainer
+
+    opts = _to_opts_string(opts)
 
     triangle_dict_in: Dict['str', Any] = {'vertices': points}
 

--- a/nanomesh/image2mesh/_mesher2d/_mesher.py
+++ b/nanomesh/image2mesh/_mesher2d/_mesher.py
@@ -296,12 +296,10 @@ class Mesher2D(Mesher, ndim=2):
         mesh : MeshContainer
             Triangulated 2D mesh with domain labels
         """
-        for var in 'pAe':
-            if var not in opts:
-                opts = f'{opts}{var}'
-        kwargs['opts'] = opts
-
-        mesh = self.contour.triangulate(**kwargs)
+        default_opts = {'p': True, 'A': True, 'e': True}
+        mesh = self.contour.triangulate(opts=opts,
+                                        default_opts=default_opts,
+                                        **kwargs)
 
         return mesh
 

--- a/nanomesh/image2mesh/_mesher3d/_mesher.py
+++ b/nanomesh/image2mesh/_mesher3d/_mesher.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from skimage import measure, morphology
 
-from nanomesh import Volume, tetrahedralize, triangulate
+from nanomesh import Volume, simple_triangulate, tetrahedralize
 from nanomesh._constants import BACKGROUND, FEATURE
 from nanomesh._doc import doc
 from nanomesh.mesh import TriangleMesh
@@ -167,7 +167,7 @@ def close_side(mesh: TriangleMesh,
 
     coords = all_points[is_edge][:, keep_cols]
 
-    edge_mesh = triangulate(points=coords, opts='')
+    edge_mesh = simple_triangulate(points=coords, opts='')
     cells = edge_mesh.cells_dict['triangle'].copy()
 
     shape = cells.shape

--- a/nanomesh/mesh/_line.py
+++ b/nanomesh/mesh/_line.py
@@ -91,6 +91,6 @@ class LineMesh(Mesh, cell_dim=2):
             self.cell_data[key][side_idx] = int_label
 
     @doc(prefix='Triangulate mesh using :func:`triangulate`')
-    def triangulate(self, opts: str = 'pq30Aa100') -> MeshContainer:
+    def triangulate(self, opts: str = 'pq30Aa100', **kwargs) -> MeshContainer:
         from .._triangle_wrapper import triangulate
-        return triangulate(self, opts=opts)
+        return triangulate(self, opts=opts, **kwargs)

--- a/nanomesh/mesh/_line.py
+++ b/nanomesh/mesh/_line.py
@@ -90,34 +90,7 @@ class LineMesh(Mesh, cell_dim=2):
 
             self.cell_data[key][side_idx] = int_label
 
+    @doc(prefix='Triangulate mesh using :func:`triangulate`')
     def triangulate(self, opts: str = 'pq30Aa100') -> MeshContainer:
-        """Triangulate mesh using :func:`triangulate`.
-
-        Parameters
-        ----------
-        opts : str, optional
-            Options passed to :func:`triangulate`. For more info,
-            see: https://rufat.be/triangle/API.html#triangle.triangulate
-
-        Returns
-        -------
-        mesh : MeshContainer
-            2D mesh with domain labels.
-        """
         from .._triangle_wrapper import triangulate
-        points = self.points
-        segments = self.cells
-        regions = [(m.point[0], m.point[1], m.label, m.constraint)
-                   for m in self.region_markers]
-
-        segment_markers = self.cell_data.get('segment_markers', None)
-
-        mesh = triangulate(points=points,
-                           segments=segments,
-                           regions=regions,
-                           segment_markers=segment_markers,
-                           opts=opts)
-
-        fields = {m.label: m.name for m in self.region_markers if m.name}
-        mesh.set_field_data('triangle', fields)
-        return mesh
+        return triangulate(self, opts=opts)

--- a/nanomesh/mesh/_mesh.py
+++ b/nanomesh/mesh/_mesh.py
@@ -247,7 +247,6 @@ class Mesh(object, metaclass=DocFormatterMeta):
         idx = self.cell_data[key] != label
 
         for k, v in self.cell_data.items():
-            print(k, v, idx)
             self.cell_data[k] = v[idx]
             pass
 

--- a/nanomesh/mesh/_triangle.py
+++ b/nanomesh/mesh/_triangle.py
@@ -134,7 +134,8 @@ class TriangleMesh(Mesh, PruneZ0Mixin, cell_dim=3):
         )
         return TriangleMesh(points=points, cells=cells)
 
-    @doc(tetrahedralize, prefix='Tetrahedralize a 3D triangle mesh')
+    @doc(tetrahedralize,
+         prefix='Tetrahedralize mesh using :func:`tetrahedralize`')
     def tetrahedralize(self, **kwargs) -> 'MeshContainer':
         mesh = tetrahedralize(self, **kwargs)
         return mesh

--- a/nanomesh/utils.py
+++ b/nanomesh/utils.py
@@ -1,9 +1,64 @@
 from itertools import tee
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from .mesh import TriangleMesh
+
+
+def _to_opts_string(inp: Any,
+                    *,
+                    sep: str = '',
+                    prefix: str = '',
+                    defaults: dict = None) -> str:
+    """Convert raw opts input to opts string for tetgen or triangle.
+
+    Parameters
+    ----------
+    inp : Any
+        Input object, str, dict, or None
+    sep : str, optional
+        Separator for parameters.
+    prefix : str, optional
+        Prefix for paramaters.
+    defaults : dict
+        Dictionary with default options.
+
+    Returns
+    -------
+    opts : str
+        Opts string
+    """
+    if defaults is None:
+        defaults = {}
+
+    if inp is None:
+        inp = ''
+
+    if isinstance(inp, str):
+        for k, v in defaults.items():
+            if k not in inp:
+                inp = f'{inp}{sep}{prefix}{k}{v}'
+        return inp
+
+    if not isinstance(inp, dict):
+        raise ValueError(f'Cannot convert {type(inp)} to opts string.')
+
+    opts_list = []
+    inp = {**defaults, **inp}
+
+    for k, v in inp.items():
+        if v is False:
+            continue
+        elif v is True:
+            v = ''
+
+        opts_list.append(f'{prefix}{k}{v}')
+
+    opts = sep.join(opts_list)
+
+    return opts
 
 
 # https://docs.python.org/3.8/library/itertools.html#itertools-recipes

--- a/nanomesh/utils.py
+++ b/nanomesh/utils.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 from itertools import tee
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .mesh import TriangleMesh
+if TYPE_CHECKING:
+    from .mesh import TriangleMesh
 
 
 def _to_opts_string(inp: Any,
@@ -38,6 +41,10 @@ def _to_opts_string(inp: Any,
 
     if isinstance(inp, str):
         for k, v in defaults.items():
+            if v is False:
+                continue
+            elif v is True:
+                v = ''
             if k not in inp:
                 inp = f'{inp}{sep}{prefix}{k}{v}'
         return inp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from nanomesh.image import SliceViewer
+from nanomesh.utils import _to_opts_string
 
 
 def test_SliceViewer_fails():
@@ -43,3 +44,39 @@ def test_pairwise():
     inp = range(3)
     out = pairwise(inp)
     assert list(out) == [(0, 1), (1, 2)]
+
+
+@pytest.mark.parametrize('opts,defaults,expected', (
+    ('pq30', {
+        'A': True,
+        'q': 20
+    }, 'pAq30'),
+    ('p', {
+        'A': True,
+        'q': 20
+    }, 'pAq20'),
+    ('p', {
+        'A': False,
+        'q': 20
+    }, 'pq20'),
+))
+def test_to_opts_string_defaults(opts, defaults, expected):
+    ret = _to_opts_string(opts, defaults=defaults)
+    assert ret == expected
+
+
+@pytest.mark.parametrize('opts,prefix,sep,expected', (
+    ({
+        'p': True,
+        'A': True,
+        'q': 30
+    }, '-', ' ', '-p -A -q30'),
+    ({
+        'p': True,
+        'A': True,
+        'q': 30
+    }, '', '', 'pAq30'),
+))
+def test_to_opts_string_formatting(opts, prefix, sep, expected):
+    ret = _to_opts_string(opts, prefix=prefix, sep=sep)
+    assert ret == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_pairwise():
     ('pq30', {
         'A': True,
         'q': 20
-    }, 'pAq30'),
+    }, 'pq30A'),
     ('p', {
         'A': True,
         'q': 20


### PR DESCRIPTION
This PR adds a new `triangulate` function that takes a `LineMesh` as input, making it consistent with `tetrahedralize`. The old function has been renamed to `simple_triangulate`.

Options `opts` can now also be passed as a dict (instead of a str).

Closes #221