### PR TITLE
Add method to remove points that do not belong to any cells

### DIFF
--- a/nanomesh/mesh/_mesh.py
+++ b/nanomesh/mesh/_mesh.py
@@ -231,8 +231,8 @@ class Mesh(object, metaclass=DocFormatterMeta):
         for key, data in self.cell_data.items():
             self.cell_data[key] = data[::-1]
 
-    def purge(self, *, label: int, key: str = None):
-        """Purge cell data matching given label.
+    def remove_cells(self, *, label: int, key: str = None):
+        """Remove cells with cell data matching given label.
 
         Parameters
         ----------
@@ -251,9 +251,9 @@ class Mesh(object, metaclass=DocFormatterMeta):
             pass
 
         self.cells = self.cells[idx]
-        self.remove_orphaned_points()
+        self.remove_loose_points()
 
-    def remove_orphaned_points(self):
+    def remove_loose_points(self):
         """Remove points that do not belong to any cells."""
         unique = np.unique(self.cells)
         self.points = np.take(self.points, unique, axis=0)

--- a/nanomesh/mesh/_mesh.py
+++ b/nanomesh/mesh/_mesh.py
@@ -251,3 +251,20 @@ class Mesh(object, metaclass=DocFormatterMeta):
             pass
 
         self.cells = self.cells[idx]
+        self.remove_orphaned_points()
+
+    def remove_orphaned_points(self):
+        """Remove points that do not belong to any cells."""
+        unique = np.unique(self.cells)
+        self.points = np.take(self.points, unique, axis=0)
+
+        mapping = np.vstack([unique, np.arange(len(unique))])
+
+        shape = self.cells.shape
+        new_cells = self.cells.ravel()
+
+        mask = np.in1d(new_cells, mapping[0, :])
+        new_cells[mask] = mapping[1,
+                                  np.searchsorted(mapping[
+                                      0, :], new_cells[mask])]
+        self.cells = new_cells.reshape(shape)

--- a/notebooks/finite_elements/how_to_use_with_sfepy_horse.ipynb
+++ b/notebooks/finite_elements/how_to_use_with_sfepy_horse.ipynb
@@ -160,7 +160,7 @@
     "\n",
     "In the next cell we extract the triangle mesh and prepare the mesh for SfePy.\n",
     "\n",
-    "1. Remove triangles representing the horse using the `Mesh.purge()` method.\n",
+    "1. Remove triangles representing the horse using the `Mesh.remove_cells()` method.\n",
     "2. Flip and rotate the coordinates. This ensures the mesh has the correct orientation."
    ]
   },
@@ -202,7 +202,7 @@
     "import numpy as np\n",
     "\n",
     "triangles = nanomesh_mesh.get('triangle')\n",
-    "triangles.purge(label=2, key='physical')\n",
+    "triangles.remove_cells(label=2, key='physical')\n",
     "\n",
     "triangles.points = np.flip(triangles.points, axis=1)\n",
     "triangles.points[:,1] = -triangles.points[:,1]\n",

--- a/notebooks/finite_elements/how_to_use_with_sfepy_horse.md
+++ b/notebooks/finite_elements/how_to_use_with_sfepy_horse.md
@@ -74,14 +74,14 @@ nanomesh_mesh.plot()
 
 In the next cell we extract the triangle mesh and prepare the mesh for SfePy.
 
-1. Remove triangles representing the horse using the `Mesh.purge()` method.
+1. Remove triangles representing the horse using the `Mesh.remove_cells()` method.
 2. Flip and rotate the coordinates. This ensures the mesh has the correct orientation.
 
 ```python
 import numpy as np
 
 triangles = nanomesh_mesh.get('triangle')
-triangles.purge(label=2, key='physical')
+triangles.remove_cells(label=2, key='physical')
 
 triangles.points = np.flip(triangles.points, axis=1)
 triangles.points[:,1] = -triangles.points[:,1]

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -92,6 +92,17 @@ def test_reverse_cell_order(line_tri_mesh, cell_type):
 
 @pytest.mark.parametrize('key', (None, 'labels'))
 def test_purge(triangle_mesh_2d, key):
+    npoints = len(triangle_mesh_2d.points)
     np.testing.assert_equal(triangle_mesh_2d.labels, np.arange(5))
     triangle_mesh_2d.purge(label=4, key=key)
     np.testing.assert_equal(triangle_mesh_2d.labels, np.arange(4))
+    # ensure that orphaned points are be removed
+    assert len(triangle_mesh_2d.points) == npoints - 1
+
+
+def test_remove_orphaned_points(triangle_mesh_2d):
+    i = 1
+    unorphaned = triangle_mesh_2d.points[i:]
+    triangle_mesh_2d.cells = triangle_mesh_2d.cells[i:]
+    triangle_mesh_2d.remove_orphaned_points()
+    np.testing.assert_equal(triangle_mesh_2d.points, unorphaned)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -91,18 +91,18 @@ def test_reverse_cell_order(line_tri_mesh, cell_type):
 
 
 @pytest.mark.parametrize('key', (None, 'labels'))
-def test_purge(triangle_mesh_2d, key):
+def test_remove_cells(triangle_mesh_2d, key):
     npoints = len(triangle_mesh_2d.points)
     np.testing.assert_equal(triangle_mesh_2d.labels, np.arange(5))
-    triangle_mesh_2d.purge(label=4, key=key)
+    triangle_mesh_2d.remove_cells(label=4, key=key)
     np.testing.assert_equal(triangle_mesh_2d.labels, np.arange(4))
     # ensure that orphaned points are be removed
     assert len(triangle_mesh_2d.points) == npoints - 1
 
 
-def test_remove_orphaned_points(triangle_mesh_2d):
+def test_remove_loose_points(triangle_mesh_2d):
     i = 1
     unorphaned = triangle_mesh_2d.points[i:]
     triangle_mesh_2d.cells = triangle_mesh_2d.cells[i:]
-    triangle_mesh_2d.remove_orphaned_points()
+    triangle_mesh_2d.remove_loose_points()
     np.testing.assert_equal(triangle_mesh_2d.points, unorphaned)


### PR DESCRIPTION
This PR adds a method to remove points (`.remove_loose_points`) that do not belong to any cells.

Renames `purge` -> `remove_cells`

Closes #261