### PR TITLE
Remove thin polygons with area = 0 causing the program to hang

### DIFF
--- a/nanomesh/image2mesh/_mesher2d/_mesher.py
+++ b/nanomesh/image2mesh/_mesher2d/_mesher.py
@@ -206,6 +206,10 @@ class Mesher2D(Mesher, ndim=2):
         ]
         polygons = [polygon.remove_duplicate_points() for polygon in polygons]
 
+        # remove polygons with no area,
+        # fixes https://github.com/hpgem/nanomesh/issues/86
+        polygons = [polygon for polygon in polygons if len(polygon) > 2]
+
         regions = _generate_regions(polygons)
         regions.append(_generate_background_region(polygons, self.bbox))
 


### PR DESCRIPTION
This PR removes any polygons consisting of 2 points or less. These are caused by setting `precision` > 0 in `Mesher2D.find_contours()`. The polygons causing problems consist of 1 or 2 points. These cannot be dealt with by the triangulation or region marker assignment, causing the program to hang.

Closes #86 